### PR TITLE
Add Selenium Tests

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -20,15 +20,14 @@ services:
     - tomcat-pn
     - solr
     - fuseki
+    - indexer
     - sosol
   sosol:
     build: sosol
     ports:
     - "8080:8080"
     volumes:
-    # waiting for /srv/data/papyri.info/lockfiles/repo_clone/canonical_cloned.lock
-    - ./selenium-ruby/shim/lockfiles/canonical_cloned.lock:/srv/data/papyri.info/lockfiles/repo_clone/canonical_cloned.lock #add shim
-    # - repo:/srv
+    - repo-test:/srv
     - ./sosol-compose:/opt/sosol-compose
     command: /opt/sosol-compose/migrate-and-copy.sh
     links:
@@ -53,16 +52,36 @@ services:
     volumes:
     - ./navigator:/navigator
     - repo-test:/srv
+    - solr_data-test:/solr
     links:
     - "fuseki"
     env_file:
       - .env
+  indexer:
+    build: indexer
+    depends_on:
+      navigator:
+        condition: service_completed_successfully
+      fuseki:
+        condition: service_started
+      solr:
+        condition: service_started
+    volumes:
+    - ./epidoc-xslt:/epidoc-xslt
+    - repo-test:/srv
+    links:
+    - "fuseki"
+    - "solr"
+    cap_add:
+    - SYS_PTRACE
+    security_opt:
+    - apparmor:unconfined
   fuseki:
     # built from https://github.com/dcthree/docker-fuseki
     image: ryanfb/fuseki
-    # volumes:
-    # - repo:/srv
-    # - fuseki_data:/data
+    volumes:
+    - repo-test:/srv
+    - fuseki_data:/data
     cpu_count: 2
     environment:
     - OPTS=--port=8090 --tdb2 --loc=/data --update /pi
@@ -79,20 +98,19 @@ services:
     build: solr
     ports:
     - "8983:8983"
-    # volumes:
-    # - solr_data:/opt/solr/server/solr
+    volumes:
+    - solr_data-test:/opt/solr/server/solr
     environment:
     - SOLR_JAVA_MEM=-Xms1G -Xmx8G
     depends_on:
-    - navigator
+      navigator:
+        condition: service_completed_successfully
   tomcat-pn:
     build: tomcat-pn
     links:
     - "postgres"
     - "fuseki"
     volumes:
-    # waiting for /srv/data/papyri.info/lockfiles/navigator/mapping_done.lock
-    - ./selenium-ruby/shim/lockfiles/mapping_done.lock:/srv/data/papyri.info/lockfiles/navigator/mapping_done.lock #add shim
     - repo-test:/srv
     depends_on:
       navigator:
@@ -138,4 +156,4 @@ networks:
 volumes:
   repo-test:
   fuseki_data:
-  solr_data:
+  solr_data-test:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -38,44 +38,15 @@ services:
     - xsugar
   repo_clone:
     build: repo_clone
-    volumes:
-    - ./:/docker-compose
-    - repo:/srv
   xsugar:
     build: xsugar
-    # ports:
-    # - "9999:9999"
-    volumes:
-    - maven:/root/.m2
   navigator:
     build: navigator-compose
     depends_on:
     - repo_clone
     - fuseki
-    volumes:
-    - ./navigator:/navigator
-    - repo:/srv
-    - maven:/root/.m2
-    - solr_data:/solr
     links:
     - "fuseki"
-  # indexer:
-  #   build: indexer
-  #   depends_on:
-  #   - navigator
-  #   - fuseki
-  #   - solr
-  #   volumes:
-  #   - ./epidoc-xslt:/epidoc-xslt
-  #   - repo:/srv
-  #   - maven:/root/.m2
-  #   links:
-  #   - "fuseki"
-  #   - "solr"
-  #   cap_add:
-  #   - SYS_PTRACE
-  #   security_opt:
-  #   - apparmor:unconfined
   fuseki:
     # built from https://github.com/dcthree/docker-fuseki
     image: ryanfb/fuseki
@@ -94,8 +65,6 @@ services:
     environment:
     - POSTGRES_USER=papyri
     - POSTGRES_HOST_AUTH_METHOD=trust
-    volumes:
-    - postgres_data:/var/lib/postgresql/data
   solr:
     build: solr
     ports:
@@ -111,8 +80,6 @@ services:
     links:
     - "postgres"
     - "fuseki"
-    # ports:
-    # - "8080:8080"
     volumes:
     - repo:/srv
     depends_on:
@@ -137,6 +104,14 @@ services:
 
   selenium:
     image: selenium/standalone-chromium:latest
+    links: 
+      - "httpd"
+    # # Test to see if the service is healthy
+    # healthcheck: 
+    #   test: ["CMD", "curl", "-f", "http://httpd:80/"]
+    #   interval: 20s
+    #   timeout: 15s
+    #   retries: 5
     ports:
     - "4444:4444"
     - "7900:7900"
@@ -150,7 +125,5 @@ networks:
 
 volumes:
   repo:
-  maven:
   fuseki_data:
   solr_data:
-  postgres_data:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -89,8 +89,10 @@ services:
   ruby_acceptance_tests:
     build: selenium-ruby
     depends_on:
-    - selenium
-    - httpd
+      httpd:
+        condition: service_started
+      selenium:
+        condition: service_healthy
     ports:
     - "1111:1111"
     links:
@@ -99,25 +101,23 @@ services:
     environment:
     - SELENIUM_HOST=selenium
     - SELENIUM_PORT=4444
-    profiles:
-      - test
 
   selenium:
-    image: selenium/standalone-chromium:latest
+    image: selenium/standalone-chromium:4.24
     links: 
       - "httpd"
-    # # Test to see if the service is healthy
-    # healthcheck: 
-    #   test: ["CMD", "curl", "-f", "http://httpd:80/"]
-    #   interval: 20s
-    #   timeout: 15s
-    #   retries: 5
+    # Test to see if the service is healthy
+    # Testing here b/c installing curl on apache2.2(httpd) is a pain
+    # bc the package repos don't exist anymore
+    healthcheck: 
+      test: ["CMD", "curl", "-f", "http://httpd:80/"]
+      interval: 20s
+      timeout: 15s
+      retries: 5
     ports:
     - "4444:4444"
     - "7900:7900"
     shm_size: 2g
-    profiles:
-      - test
 
 networks:
   selenium-net:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,156 @@
+# todo: simplify or load minimum test info needed from local files 
+# for teardown and startup and to remove volumes
+
+services:
+
+  httpd:
+    build: apache
+    links:
+    - "tomcat-pn"
+    - "xsugar"
+    - "fuseki"
+    - "solr"
+    - "sosol"
+    volumes:
+    - repo:/srv
+    ports:
+    - "8000:80"
+    depends_on:
+    - xsugar
+    - tomcat-pn
+    - solr
+    - fuseki
+    - sosol
+  sosol:
+    build: sosol
+    ports:
+    - "8080:8080"
+    volumes:
+    - repo:/srv
+    - ./sosol-compose:/opt/sosol-compose
+    command: /opt/sosol-compose/migrate-and-copy.sh
+    links:
+    - "xsugar"
+    - "postgres"
+    depends_on:
+    - postgres
+    - repo_clone
+    - xsugar
+  repo_clone:
+    build: repo_clone
+    volumes:
+    - ./:/docker-compose
+    - repo:/srv
+  xsugar:
+    build: xsugar
+    # ports:
+    # - "9999:9999"
+    volumes:
+    - maven:/root/.m2
+  navigator:
+    build: navigator-compose
+    depends_on:
+    - repo_clone
+    - fuseki
+    volumes:
+    - ./navigator:/navigator
+    - repo:/srv
+    - maven:/root/.m2
+    - solr_data:/solr
+    links:
+    - "fuseki"
+  # indexer:
+  #   build: indexer
+  #   depends_on:
+  #   - navigator
+  #   - fuseki
+  #   - solr
+  #   volumes:
+  #   - ./epidoc-xslt:/epidoc-xslt
+  #   - repo:/srv
+  #   - maven:/root/.m2
+  #   links:
+  #   - "fuseki"
+  #   - "solr"
+  #   cap_add:
+  #   - SYS_PTRACE
+  #   security_opt:
+  #   - apparmor:unconfined
+  fuseki:
+    # built from https://github.com/dcthree/docker-fuseki
+    image: ryanfb/fuseki
+    volumes:
+    - repo:/srv
+    - fuseki_data:/data
+    cpu_count: 2
+    environment:
+    - OPTS=--port=8090 --tdb2 --loc=/data --update /pi
+    - JVM_ARGS=-Xmx8192M
+    - JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
+    ports:
+    - "8090:8090"
+  postgres:
+    image: postgres:13
+    environment:
+    - POSTGRES_USER=papyri
+    - POSTGRES_HOST_AUTH_METHOD=trust
+    volumes:
+    - postgres_data:/var/lib/postgresql/data
+  solr:
+    build: solr
+    ports:
+    - "8983:8983"
+    volumes:
+    - solr_data:/opt/solr/server/solr
+    environment:
+    - SOLR_JAVA_MEM=-Xms1G -Xmx8G
+    depends_on:
+    - navigator
+  tomcat-pn:
+    build: tomcat-pn
+    links:
+    - "postgres"
+    - "fuseki"
+    # ports:
+    # - "8080:8080"
+    volumes:
+    - repo:/srv
+    depends_on:
+    - navigator
+    
+    
+  ruby_acceptance_tests:
+    build: selenium-ruby
+    depends_on:
+    - selenium
+    - httpd
+    ports:
+    - "1111:1111"
+    links:
+    - "selenium"
+    - "httpd"
+    environment:
+    - SELENIUM_HOST=selenium
+    - SELENIUM_PORT=4444
+    profiles:
+      - test
+
+  selenium:
+    image: selenium/standalone-chromium:latest
+    ports:
+    - "4444:4444"
+    - "7900:7900"
+    shm_size: 2g
+    profiles:
+      - test
+
+networks:
+  selenium-net:
+    driver: bridge
+
+volumes:
+  repo:
+  maven:
+  fuseki_data:
+  solr_data:
+  postgres_data:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -27,7 +27,8 @@ services:
     - "8080:8080"
     volumes:
     # waiting for /srv/data/papyri.info/lockfiles/repo_clone/canonical_cloned.lock
-    - repo:/srv
+    - ./selenium-ruby/shim/lockfiles/canonical_cloned.lock:/srv/data/papyri.info/lockfiles/repo_clone/canonical_cloned.lock #add shim
+    # - repo:/srv
     - ./sosol-compose:/opt/sosol-compose
     command: /opt/sosol-compose/migrate-and-copy.sh
     links:
@@ -83,6 +84,7 @@ services:
     - "fuseki"
     volumes:
     # waiting for /srv/data/papyri.info/lockfiles/navigator/mapping_done.lock
+    # - ./selenium-ruby/shim/lockfiles/mapping_done.lock:/srv/data/papyri.info/lockfiles/navigator/mapping_done.lock #add shim
     - repo:/srv
     depends_on:
     - navigator

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -12,7 +12,7 @@ services:
     - "solr"
     - "sosol"
     volumes:
-    - repo:/srv
+    - repo-test:/srv
     ports:
     - "8000:80"
     depends_on:
@@ -40,6 +40,9 @@ services:
     - xsugar
   repo_clone:
     build: repo_clone
+    volumes:
+    - ./:/docker-compose
+    - repo-test:/srv
   xsugar:
     build: xsugar
   navigator:
@@ -47,8 +50,13 @@ services:
     depends_on:
     - repo_clone
     - fuseki
+    volumes:
+    - ./navigator:/navigator
+    - repo-test:/srv
     links:
     - "fuseki"
+    env_file:
+      - .env
   fuseki:
     # built from https://github.com/dcthree/docker-fuseki
     image: ryanfb/fuseki
@@ -84,11 +92,11 @@ services:
     - "fuseki"
     volumes:
     # waiting for /srv/data/papyri.info/lockfiles/navigator/mapping_done.lock
-    # - ./selenium-ruby/shim/lockfiles/mapping_done.lock:/srv/data/papyri.info/lockfiles/navigator/mapping_done.lock #add shim
-    - repo:/srv
+    - ./selenium-ruby/shim/lockfiles/mapping_done.lock:/srv/data/papyri.info/lockfiles/navigator/mapping_done.lock #add shim
+    - repo-test:/srv
     depends_on:
-    - navigator
-    
+      navigator:
+        condition: service_completed_successfully
     
   ruby_acceptance_tests:
     build: selenium-ruby
@@ -128,6 +136,6 @@ networks:
     driver: bridge
 
 volumes:
-  repo:
+  repo-test:
   fuseki_data:
   solr_data:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -26,6 +26,7 @@ services:
     ports:
     - "8080:8080"
     volumes:
+    # waiting for /srv/data/papyri.info/lockfiles/repo_clone/canonical_cloned.lock
     - repo:/srv
     - ./sosol-compose:/opt/sosol-compose
     command: /opt/sosol-compose/migrate-and-copy.sh
@@ -50,9 +51,9 @@ services:
   fuseki:
     # built from https://github.com/dcthree/docker-fuseki
     image: ryanfb/fuseki
-    volumes:
-    - repo:/srv
-    - fuseki_data:/data
+    # volumes:
+    # - repo:/srv
+    # - fuseki_data:/data
     cpu_count: 2
     environment:
     - OPTS=--port=8090 --tdb2 --loc=/data --update /pi
@@ -69,8 +70,8 @@ services:
     build: solr
     ports:
     - "8983:8983"
-    volumes:
-    - solr_data:/opt/solr/server/solr
+    # volumes:
+    # - solr_data:/opt/solr/server/solr
     environment:
     - SOLR_JAVA_MEM=-Xms1G -Xmx8G
     depends_on:
@@ -81,6 +82,7 @@ services:
     - "postgres"
     - "fuseki"
     volumes:
+    # waiting for /srv/data/papyri.info/lockfiles/navigator/mapping_done.lock
     - repo:/srv
     depends_on:
     - navigator

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -81,7 +81,7 @@ services:
     image: ryanfb/fuseki
     volumes:
     - repo-test:/srv
-    - fuseki_data:/data
+    - fuseki_data-test:/data
     cpu_count: 2
     environment:
     - OPTS=--port=8090 --tdb2 --loc=/data --update /pi
@@ -123,6 +123,8 @@ services:
         condition: service_started
       selenium:
         condition: service_healthy
+      indexer:
+        condition: service_completed_successfully
     ports:
     - "1111:1111"
     links:
@@ -155,5 +157,5 @@ networks:
 
 volumes:
   repo-test:
-  fuseki_data:
+  fuseki_data-test:
   solr_data-test:

--- a/selenium-ruby/Dockerfile
+++ b/selenium-ruby/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:latest
+
+ADD . /app
+WORKDIR /app
+
+RUN bundle install
+
+CMD ["rspec"]

--- a/selenium-ruby/Gemfile
+++ b/selenium-ruby/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'selenium-webdriver'
+gem 'webdrivers'
+gem 'rspec'
+gem 'capybara'

--- a/selenium-ruby/spec/basic_health_spec.rb
+++ b/selenium-ruby/spec/basic_health_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe "Basic Health Check Tests", type: :system do
   it "should take a screenshot of homepage" do
-    visit 'http://httpd:80'
+    visit '/'
     save_screenshot('/opt/selenium/image.png')
   end
   # go to google.com and test the page title
   it "should go to homepage and test page title" do
-    visit 'http://httpd:80'
+    visit '/'
     expect(page).to have_title('Papyri.info')
   end
 end

--- a/selenium-ruby/spec/basic_health_spec.rb
+++ b/selenium-ruby/spec/basic_health_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe "Basic Health Check Tests", type: :system do
+  it "should take a screenshot of homepage" do
+    visit 'http://httpd:80'
+    save_screenshot('/opt/selenium/image.png')
+  end
+  # go to google.com and test the page title
+  it "should go to homepage and test page title" do
+    visit 'http://httpd:80'
+    expect(page).to have_title('Papyri.info')
+  end
+end

--- a/selenium-ruby/spec/rails_helper.rb
+++ b/selenium-ruby/spec/rails_helper.rb
@@ -20,3 +20,4 @@ end
 
 Capybara.default_driver = :selenium_remote
 Capybara.javascript_driver = :selenium_remote
+Capybara.app_host = 'http://httpd:80'

--- a/selenium-ruby/spec/rails_helper.rb
+++ b/selenium-ruby/spec/rails_helper.rb
@@ -1,0 +1,22 @@
+require 'capybara'
+require 'capybara/rspec'
+require 'selenium-webdriver'
+
+Capybara.register_driver :selenium_remote do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument("--window-size=1400,1400")
+  options.add_argument("--no-sandbox")
+  options.add_argument("--disable-dev-shm-usage")  
+  client = Selenium::WebDriver::Remote::Http::Default.new
+  client.open_timeout = 8
+  client.read_timeout = 8
+  Capybara::Selenium::Driver.new(app,
+    browser: :remote,
+    url: 'http://selenium:4444/wd/hub',
+    options: options,
+    http_client: client
+  )
+end
+
+Capybara.default_driver = :selenium_remote
+Capybara.javascript_driver = :selenium_remote

--- a/selenium-ruby/spec/spec_helper.rb
+++ b/selenium-ruby/spec/spec_helper.rb
@@ -2,7 +2,12 @@
 require 'rails_helper'
 
 RSpec.configure do |config|
-  config.before(:each) do
+  config.before(:suite) do
     driven_by(:selenium_remote)
+  end
+
+  config.after(:suite) do
+    # Assuming we need to quit the driver, adjust as necessary
+    Capybara.current_session.driver.quit
   end
 end

--- a/selenium-ruby/spec/spec_helper.rb
+++ b/selenium-ruby/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.configure do |config|
+  config.before(:each) do
+    driven_by(:selenium_remote)
+  end
+end


### PR DESCRIPTION
This is a pretty basic setup for running selenium tests. I replicated the setup but without volumes for most services. 
`docker compose run -f docker-compose-test.yml run ruby_acceptance_tests`

### New Services

- selenium
  - Selenium grid server running chromium browser
- ruby_acceptance_tests
  -  Runs ruby / capybara / rspec  (I figured this would be preferred to Java)
  
As a proof-of-concept it takes a screenshot and tests the Title

We've discussed adding snapshots and adding sample test data, but that's still todo and makes sense to add along with tests that use whatever data is needed for the test.

