### PR TITLE
Bypass some indexer steps with solr backups to speed up testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.log
 .env
+
+selenium-ruby/backups/*
+!selenium-ruby/backups/solr-backup.sh

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -58,7 +58,10 @@ services:
     env_file:
       - .env
   indexer:
-    build: indexer
+    build:
+      context: indexer
+      args:
+        INDEXING_ARGS: lein run generate-pages
     depends_on:
       navigator:
         condition: service_completed_successfully
@@ -100,8 +103,14 @@ services:
     - "8983:8983"
     volumes:
     - solr_data-test:/opt/solr/server/solr
+    - type: bind
+      source: ./selenium-ruby/backups
+      target: /opt/solr/server/solr/backups
     environment:
     - SOLR_JAVA_MEM=-Xms1G -Xmx8G
+    - SOLR_BACKUP_URL
+    - USE_SOLR_BACKUPS
+    command: /bin/sh -c "/opt/solr/server/solr/backups/solr-backup.sh"
     depends_on:
       navigator:
         condition: service_completed_successfully
@@ -116,7 +125,7 @@ services:
       navigator:
         condition: service_completed_successfully
     
-  ruby_acceptance_tests:
+  selenium_ui_tests:
     build: selenium-ruby
     depends_on:
       httpd:
@@ -143,7 +152,7 @@ services:
     # bc the package repos don't exist anymore
     healthcheck: 
       test: ["CMD", "curl", "-f", "http://httpd:80/"]
-      interval: 20s
+      interval: 45s
       timeout: 15s
       retries: 5
     ports:

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:focal
 MAINTAINER Ryan Baumann <ryan.baumann@gmail.com>
 
+# arguments passed to the clojure indexer script
+ARG INDEXING_ARGS="lein run biblio && lein run load-lemmas && lein run"
+
 # Install Git
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
@@ -16,4 +19,5 @@ ENV LEIN_ROOT true
 ADD https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein /usr/local/bin/lein
 RUN chmod a+x /usr/local/bin/lein
 ADD . /root
+RUN sed -i "s/lein run biblio && lein run load-lemmas && lein run/$INDEXING_ARGS/g" /root/run-indexing.sh
 CMD /root/run-indexing.sh

--- a/selenium-ruby/backups/solr-backup.sh
+++ b/selenium-ruby/backups/solr-backup.sh
@@ -1,0 +1,41 @@
+# #!/bin/bash
+
+# # # Define variables
+BIBLIO_CORE="biblio-search"
+PN_CORE="pn-search"
+MORPH_CORE="morph-search"
+SOLR_URL="http://localhost:8983/solr"
+# SNAPSHOT_NAME="20240913185922221"
+BIBLIO_BACKUP_LOCATION="/opt/solr/server/solr/biblio-search/data/snapshot.20240919154139836"
+PN_BACKUP_LOCATION="/opt/solr/server/solr/pn-search/data/snapshot.20240919154042991"
+MORPH_BACKUP_LOCATION="/opt/solr/server/solr/morph-search/data/snapshot.20240919153922194"
+SOLR_BACKUP_LOCATION="${SOLR_BACKUP_URL:-https://automation.lib.duke.edu/papyri-automation/}"
+
+# If USE_SOLR_BACKUPS is not set to true, do the following:
+if [ "$USE_SOLR_BACKUPS" != "true" ]; then
+  /bin/sh -c /home/solr/start-solr.sh
+else
+  # Check to see if /opt/solr/server/solr/backups/biblio-search exists
+  if [ ! -d "/opt/solr/server/solr/backups/biblio-search" ] ||
+    [ ! -d "/opt/solr/server/solr/backups/pn-search" ] ||
+    [ ! -d "/opt/solr/server/solr/backups/morph-search"]; then
+    echo "Backups not found grabbing data from lib automation..."
+    wget -r --no-parent -P "/opt/solr/server/solr/backups" -nH --cut-dirs=1 --reject "index.html*" $SOLR_BACKUP_LOCATION || exit 1
+  fi
+
+  solr-foreground &
+
+  # Create the Solr cores
+  sleep 5 && 
+
+  unzip /opt/solr/server/solr/backups/biblio-search/snapshot.20240919154139836.zip -d $BIBLIO_BACKUP_LOCATION &&
+  unzip /opt/solr/server/solr/backups/pn-search/snapshot.20240919154042991.zip -d $PN_BACKUP_LOCATION &&
+  unzip /opt/solr/server/solr/backups/morph-search/snapshot.20240919153922194.zip -d $MORPH_BACKUP_LOCATION
+
+  # # # Restore the backup
+  curl "$SOLR_URL/$BIBLIO_CORE/replication?command=restore&name=20240919154139836" &
+  curl "$SOLR_URL/$PN_CORE/replication?command=restore&name=20240919154042991" &
+  curl "$SOLR_URL/$MORPH_CORE/replication?command=restore&name=20240919153922194" &
+
+  wait
+fi


### PR DESCRIPTION
This work intends to speed up selenium tests by limiting the indexer service to only building the required html pages. Building the solr index is done by restoring backups. This reduces the full runtime by about 8 minutes and speeds up future runtimes by pulling the data from a volume